### PR TITLE
Switching to Simplified BSD license, moving CONTRIBUTING doc to root

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,12 +33,12 @@ are working properly before submitting a pull request.
 0. All submitted code should conform to [__PEP8 standards__][pep8].
 
 
-[ansible_vars]: ../ansible/vars.yml "Ansible variables file"
-[dojo_settings]: ../dojo/settings.dist.py "DefectDojo settings file"
-[ansible_settings]: ../ansible/roles/webserver/templates/settings.j2 "Ansible settings template"
-[setup_py]: ../setup.py "Python setup script"
-[ansible_app]: ../ansible/roles/webserver/tasks/app.yml "Ansible app tasks"
-[setup_bash]: ../setup.bash "Bash setup script"
-[ansible_folder]: ../ansible "Ansible folder"
+[ansible_vars]: /ansible/vars.yml "Ansible variables file"
+[dojo_settings]: /dojo/settings.dist.py "DefectDojo settings file"
+[ansible_settings]: /ansible/roles/webserver/templates/settings.j2 "Ansible settings template"
+[setup_py]: /setup.py "Python setup script"
+[ansible_app]: /ansible/roles/webserver/tasks/app.yml "Ansible app tasks"
+[setup_bash]: /setup.bash "Bash setup script"
+[ansible_folder]: /ansible "Ansible folder"
 [modifying_dojo]: #modifying-defectdojo-and-testing-with-vagrant "Modifying DefectDojo and testing with Vagrant"
 [pep8]: https://www.python.org/dev/peps/pep-0008/ "PEP8"

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,12 @@
+Copyright (c) 2015, Rackspace Hosting, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ With past contributions from:
 
 # License
 
-<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a><br /><span xmlns:dct="http://purl.org/dc/terms/" property="dct:title">DefectDojo</span> created by <span xmlns:cc="http://creativecommons.org/ns#" property="cc:attributionName">Greg Anderson, Charles Neill, and Jay Paz</span> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.
+DefectDojo is licensed under the [BSD Simplified license](LICENSE.md)

--- a/license.md
+++ b/license.md
@@ -1,6 +1,0 @@
-<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a><br /><span xmlns:dct="http://purl.org/dc/terms/" property="dct:title">defect-dojo</span> created by <span xmlns:cc="http://creativecommons.org/ns#" property="cc:attributionName">Greg Anderson, Charles Neill, and Jay Paz </span> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.
-
-
-If you have any questions about DefectDojo, open an issue on
-[our repo](https://github.com/rackerlabs/django-DefectDojo) or check out
-[our documentation](./doc)


### PR DESCRIPTION
Closes #40.

- Switching to the Simplified BSD 3-clause license
- Moving CONTRIBUTING.md to root directory for consistency purposes