### PR TITLE
django-audit log 0.3.2 breaks install

### DIFF
--- a/ansible/roles/webserver/tasks/app.yml
+++ b/ansible/roles/webserver/tasks/app.yml
@@ -124,7 +124,7 @@
   sudo_user: '{{ dd_user }}'
 
 - name: Install django-auditlog
-  pip: name=django-auditlog virtualenv={{ venv_dir }}
+  pip: name=django-auditlog version=0.3.1 virtualenv={{ venv_dir }}
   sudo: yes
   sudo_user: '{{ dd_user }}'
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'django-easy-pdf',
         'xhtml2pdf>=0.0.6',
         'reportlab',
-        'django-auditlog',
+        'django-auditlog==0.3.1',
         'vobject'],
     url='https://github.com/rackerlabs/django-DefectDojo'
 )


### PR DESCRIPTION
Issue found by Michael Dong. I have set dojo to install 0.3.1 rather than 0.3.2