### PR TITLE
improvements to zap parser

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -242,7 +242,7 @@ def import_scan_results(request, eid):
             try:
                 for item in parser.items:
                     sev = item.severity
-                    if sev == 'Information':
+                    if sev == 'Information' or sev == 'Informational':
                         sev = 'Info'
 
                     item.severity = sev

--- a/dojo/tools/zap/parser.py
+++ b/dojo/tools/zap/parser.py
@@ -66,6 +66,7 @@ class ZapXmlParser(object):
                     references += ref + "\n"
 
                 find = Finding(title=item.name,
+                               cwe=item.cwe,
                                description=item.desc,
                                test=test,
                                severity=severity,
@@ -178,6 +179,10 @@ class Item(object):
         self.ref = []
         if self.get_text_from_subnode('cweid'):
             self.ref.append("CWE-" + self.get_text_from_subnode('cweid'))
+            self.cwe = self.get_text_from_subnode('cweid')
+        else: self.cwe = 0
+
+            
         if self.get_text_from_subnode('wascid'):
             self.ref.append("WASC-" + self.get_text_from_subnode('wascid'))
 


### PR DESCRIPTION
In Zap (2.4.2), the lowest priority is called ‘Informational’, causing problems on import. This fixes that.