### PR TITLE
Issue #71: correcting ansible module indentation

### DIFF
--- a/ansible/roles/webserver/tasks/app.yml
+++ b/ansible/roles/webserver/tasks/app.yml
@@ -202,8 +202,8 @@
   shell: echo "from django.contrib.auth.models import User; User.objects.create_superuser('{{ dd_super_user }}', '{{ dd_super_user_email }}', '{{ dd_super_user_pass }}')" | {{ venv_dir }}/bin/python {{ dd_install_dir }}/manage.py shell && touch /home/{{ dd_user }}/.supercreated
   args:
     creates: /home/{{ dd_user }}/.supercreated
-    sudo: yes
-    sudo_user: '{{ dd_user }}'
+  sudo: yes
+  sudo_user: '{{ dd_user }}'
 
 - name: Run 'bower install' command
   command: bower install 


### PR DESCRIPTION
Correcting error message:
```
TASK [webserver : Create Django superuser] *************************************
fatal: [127.0.0.1]: FAILED! => {"changed": false, "failed": true, "msg": "unsupported parameter for module: sudo_user"}
```
The error appears to be due to errant indention of the sudo and sudo_user modules in app.yml here:
```
- name: Create Django superuser
  shell: echo "from django.contrib.auth.models import User; User.objects.create_superuser('{{ dd_super_user }}', '{{ dd_super_user_email }}', '{{ dd_super_user_pass }}')" | {{ venv_dir }}/bin/python {{ dd_install_dir }}/manage.py shell && touch /home/{{ dd_user }}/.supercreated
  args:
    creates: /home/{{ dd_user }}/.supercreated
    sudo: yes
    sudo_user: '{{ dd_user }}'
```
Removing the preceding space from the sudo and sudo_user modules allowed the installation to continue successfully.